### PR TITLE
Include notification task with include_role instead of include_tasks

### DIFF
--- a/tasks/create.yml
+++ b/tasks/create.yml
@@ -30,7 +30,8 @@
   register: _aws_kms_create_alias
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       created <a href="{{

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -1,7 +1,8 @@
 ---
 
 - name: call optional notifier for untracked keys
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message:
     attachments:
@@ -24,7 +25,8 @@
     _aws_kms_untracked_key_aliases
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       finished running role <b>aws-kms</b>

--- a/tasks/pre.yml
+++ b/tasks/pre.yml
@@ -8,7 +8,8 @@
          | sort }}
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       started running role <b>aws-kms</b>

--- a/tasks/sync_policy.yml
+++ b/tasks/sync_policy.yml
@@ -24,7 +24,8 @@
   when: not _aws_kms_key_policy_synced
 
 - name: call optional notifier
-  include_tasks: 'roles/{{ notifier_role }}/tasks/main.yml'
+  include_role:
+    name: '{{ notifier_role }}'
   vars:
     message: >
       updated polcy for <a href="{{


### PR DESCRIPTION
This is the proper way to include tasks from another role with modern Ansible.